### PR TITLE
Various punctuation and grammar tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Our Engineering Principles
 
-As a company we have done well to embrace the principles of Agile and the Lean Start-Up; we have applied them to the way in which we validate learnings related to our products - we iterate, we improve, we measure and we stop doing things. In the context of engineering as a craft, we don't always explicitly apply the same mindset. We should strive to learn, improve and ultimately deliver better quality products in shorter durations. The principles give us the framework to call out what we believe are the foundational elements that ground us, allow us to improve and allow us to iterate and grow. Autonomy without alignment and accountability is chaos; the principles strengthen the aspects related to alignment and accountability. There is an emphasis on improving our ability/speed to deliver customer value in production responsibility versus metrics only, implicit is that we mature the parts of our ecosystem that we value most. https://medium.com/@SkyscannerEng/why-engineering-principles-matter-993298f7d792
+As a company we have done well to embrace the principles of Agile and the Lean Start-Up; we have applied them to the way in which we validate learnings related to our products - we iterate, we improve, we measure and, where necessary, we change course. In the context of engineering as a craft, we don't always explicitly apply the same mindset. We should strive to learn, improve and ultimately deliver better quality products in shorter durations. The principles below give us the framework to call out what we believe are the foundational elements that ground us, allow us to improve and allow us to iterate and grow. Autonomy without alignment and accountability is chaos; the principles strengthen the aspects related to alignment and accountability. There is an emphasis on improving our ability/speed to deliver customer value in production responsibly - while we must focus on improving metrics and the availability of metrics, we must always do so with an awareness of how and where our work is delivering increased value. https://medium.com/@SkyscannerEng/why-engineering-principles-matter-993298f7d792
 
 ## We have a clear definition of success for every piece of work
 
-Every journey needs a clear destination/outcome, applied to any granularity; company, goal, epic, story/task, feature etc. As we commit, we are specific and unambiguous and we should be able to articulate both why we are doing something and when we will be done. The definition includes "done", see below.
+Every task, however granular, needs to be performed with a clear outcome in mind - company, goal, epic, story/task, feature etc. As we commit, we are specific and unambiguous and we should be able to articulate both why we are doing something and when we will be done. The definition includes "done" - see below.
 
 ## We ship multiple times a day and deliver customer value week in, week out.
 
@@ -13,17 +13,17 @@ We deliver tangible outcomes regularly and sustainably. We embrace lean principl
 
 ## We use design reviews to validate every significant change
 
-Collectively as a squad, tribe or organisation we have a pool of expertise that we should capitalise on. Design reviews are a platform to share, learn, feedback and ultimately deliver better products. They result in an improved technical design and operability using learning and from best practice from others.
+Collectively as a squad, tribe or organisation we have a pool of expertise that we should capitalise on. Design reviews are a platform to share, learn, feedback and ultimately deliver better products. They result in an improved technical design and operability using learning and best practice from others.
 
 
 ## We deliver our products using our defined technology standards  
 
-As our engineering team grows we need to have the right level of consistency and standardisation. We express our opinions in what we choose to use, ensuring we can then build robust tooling to help support us at scale.. This supports multiple facets; internal open-source, developer onboarding, service ownership, freedom of movement, rotations and day-to-day operations to name a few. We focus on our customers’ problems over repeatedly making technological decisions, which in turn improves our time to production.
+As our engineering team grows we need to have the right level of consistency and standardisation. We express our opinions in what we choose to use, ensuring we can then build robust tooling to help support us at scale. This supports multiple facets; internal open-source, developer onboarding, service ownership, freedom of movement, rotations and day-to-day operations to name a few. We focus on our customers’ problems over repeatedly making technological decisions, which in turn improves our time to production.
 
 
 ## We peer review every change  
 
-Peer review supports delivery of high-quality changes. It can prevent outages and malfunctions caused by bugs, improves aspects of the code such as reducing tech debt and promotes design consistency, learning and knowledge sharing. Peer review results in a wider level of knowledge within the team in question. Internal services that impact our ability to support our external customers are considered production.
+Peer review supports delivery of high-quality changes. It can prevent outages and malfunctions caused by bugs, improves aspects of the code such as reducing tech debt and promotes design consistency, learning and knowledge-sharing. Peer review results in a wider level of knowledge within the team in question. Internal services that impact our ability to support our external customers are considered production.
 
 
 ## We cover all changes with automated tests, responsibly
@@ -33,13 +33,12 @@ Having extensive test coverage finds defects early and allows us to effectively 
 
 ## Our definitions of done include being live in production... responsibly
 
-Customer impact is only realised when our target delivery environment is customer facing (usually production). We optimise our tools, processes and planning for this delivery model. Ensuing throughput is maximised without detrimental impact on responsibility, which warrants highlighting. We want to remain accountable for delivering an uninterrupted experience to our customers.
+Customer impact is only realised when our target delivery environment is customer-facing (usually production). We optimise our tools, processes and planning for this delivery model. We want to remain accountable for delivering an uninterrupted experience to our customers.
 
 
 ## You build it, you run it
 
 To achieve World Class Engineering at Scale, we have moved towards an operating model of you build it, you run it. This fosters a sense of ownership among teams who ultimately either run, or responsibly transfer ownership . It should also ensure there is a high degree of accountability of every service/product and that we do right by the traveller/customer.
-
 
 
 ## We own and are responsible for the data we produce


### PR DESCRIPTION
* Changed 'we stop doing things' to 'we change course', which is a little more poetic and also perhaps a little less confusing
* Changed 'responsibility' in the intro to 'responsibly' - I think this was a mistake carried over from Confluence
* Made wholesale changes to last sentence of intro as it didn't make sense as written (worked with original author L.A. to update)
* Altered sentence re: granularity to improve expression and remove journey metaphor which was confusing things a bit
* Removed sentence 'Ensuing throughput is maximised without detrimental impact on responsibility, which warrants highlighting.' as felt it was unnecessary (and hard to understand)